### PR TITLE
Integration test suite

### DIFF
--- a/src/ciphers/feal.py
+++ b/src/ciphers/feal.py
@@ -196,7 +196,7 @@ def decrypt(key, text, n=32):
     return p
 
 
-def main():
+def feal():
     args = docopt(__doc__)
     text = int(args['PLAINTEXT'] or args['CIPHERTEXT'], 0)
     n = int(args['--round-number'])
@@ -215,4 +215,4 @@ def main():
 
 
 if __name__ == "__main__":
-    print(main())
+    print(feal())

--- a/src/ciphers/feal.py
+++ b/src/ciphers/feal.py
@@ -208,7 +208,7 @@ def feal():
         o = encrypt(k, text, n)
     elif args['decrypt']:
         o = decrypt(k, text, n)
-    _format = {'bin': bin, 'oct': oct, 'dec': int, 'hex': hex}
+    _format = {'bin': bin, 'oct': oct, 'dec': str, 'hex': hex}
     try:
         # format output
         return _format[args['-o']](o)

--- a/src/ciphers/feal.py
+++ b/src/ciphers/feal.py
@@ -197,6 +197,9 @@ def decrypt(key, text, n=32):
 
 
 def feal():
+    """Main entry point for FEAL cipher execution.
+    Gets arguments from docopt which parses sys.argv.
+    See http://docopt.org/ if you are not familiar with docopt argument parsing."""
     args = docopt(__doc__)
     text = int(args['PLAINTEXT'] or args['CIPHERTEXT'], 0)
     n = int(args['--round-number'])

--- a/src/ciphers/feal.py
+++ b/src/ciphers/feal.py
@@ -208,12 +208,11 @@ def main():
     _format = {'bin': bin, 'oct': oct, 'dec': int, 'hex': hex}
     try:
         # format output
-        f_o = _format[args['-o']](o)
-        print(f_o)
+        return _format[args['-o']](o)
     except KeyError:
         print("Output format must be bin, oct, dec or hex.")
         exit(1)
 
 
 if __name__ == "__main__":
-    main()
+    print(main())

--- a/src/ciphers/feal.py
+++ b/src/ciphers/feal.py
@@ -134,14 +134,14 @@ def fk(a, b):
     return concat_bits(fk0, fk1, fk2, fk3, n=8)
 
 
-def encrypt_preprocessing(text, subkeys):
+def encrypt_preprocessing(subkeys, text):
     p = text ^ concat_bits(*subkeys, n=16)
     l0, r0 = split(2, 32, p)
     p ^= l0
     return p
 
 
-def decrypt_preprocessing(text, subkeys):
+def decrypt_preprocessing(subkeys, text):
     p = text ^ concat_bits(*subkeys, n=16)
     rn, ln = split(2, 32, p)
     p = concat_bits(rn, ln, n=32) ^ rn
@@ -164,7 +164,7 @@ def decrypt_iterative_calculation(ln, rn, sk, n=32):
     return l, r
 
 
-def encrypt(text, key, n=32):
+def encrypt(key, text, n=32):
     """Encrypts the given 64-bit text with the given key and returns the 64-bit ciphertext.
     Raises error if text is longer than 64-bit or key is longer than 128-bit."""
     if text >= 2 ** 64:
@@ -172,7 +172,7 @@ def encrypt(text, key, n=32):
     if key >= 2 ** 128:
         raise ValueError("Key must be 128-bit")
     sk = key_schedule(key, n)
-    l0, r0 = split(2, 32, encrypt_preprocessing(text, sk[n:n + 4]))
+    l0, r0 = split(2, 32, encrypt_preprocessing(sk[n:n + 4], text))
     l, r = encrypt_iterative_calculation(l0, r0, sk, n)
     ln, rn = l[n], r[n]
     c = concat_bits(rn, ln, n=32) ^ rn
@@ -180,7 +180,7 @@ def encrypt(text, key, n=32):
     return c
 
 
-def decrypt(text, key, n=32):
+def decrypt(key, text, n=32):
     """Decrypts the given 64-bit ciphertext with the given key and returns the 64-bit plaintext.
     Raises error if text is longer than 64-bit or key is longer than 128-bit."""
     if text >= 2 ** 64:
@@ -188,7 +188,7 @@ def decrypt(text, key, n=32):
     if key >= 2 ** 128:
         raise ValueError("Key must be 128-bit")
     sk = key_schedule(key, n)
-    rn, ln = split(2, 32, decrypt_preprocessing(text, sk[n + 4:n + 8]))
+    rn, ln = split(2, 32, decrypt_preprocessing(sk[n + 4:n + 8], text))
     l, r = decrypt_iterative_calculation(ln, rn, sk, n)
     l0, r0 = l[0], r[0]
     p = concat_bits(l0, r0, n=32) ^ l0
@@ -202,9 +202,9 @@ def main():
     n = int(args['--round-number'])
     k = int(args['KEY'], 0)
     if args['encrypt']:
-        o = encrypt(text, k, n)
+        o = encrypt(k, text, n)
     elif args['decrypt']:
-        o = decrypt(text, k, n)
+        o = decrypt(k, text, n)
     _format = {'bin': bin, 'oct': oct, 'dec': int, 'hex': hex}
     try:
         # format output

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -35,3 +35,8 @@ class TestFeal(unittest.TestCase):
     def test_integration_feal_decrypt(self):
         p = feal()
         self.assertEqual(int(p), 0x0)
+
+    @default_decrypt_args('-o', 'bin')
+    def test_integration_feal_output_format_bin(self):
+        c = feal()
+        self.assertEqual(c, bin(0x0))

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -6,13 +6,32 @@ import test.context
 from ciphers.feal import feal
 
 
+def mock_patch_wrapper(*args, **kwargs):
+    def wrapper(fn):
+        # wraps the test function
+        @mock.patch(*args, **kwargs)  # wraps the test function
+        def _wrapper(self):
+            # needed to pass the `self` argument from `unittest` to the test function
+            return fn(self)
+
+        return _wrapper
+
+    return wrapper
+
+
+default_encrypt_args = mock_patch_wrapper('sys.argv', ['feal', 'encrypt', '0x123456789ABCDEF0123456789ABCDEF', '0'])
+
+default_decrypt_args = mock_patch_wrapper(
+    'sys.argv', ['feal', 'decrypt', '0x123456789ABCDEF0123456789ABCDEF', '0x9C9B54973DF685F8'])
+
+
 class TestFeal(unittest.TestCase):
-    @mock.patch('sys.argv', ['feal', 'encrypt', '0x123456789ABCDEF0123456789ABCDEF', '0'])
+    @default_encrypt_args
     def test_integration_feal_encrypt(self):
         c = feal()
         self.assertEqual(int(c), 0x9C9B54973DF685F8)
 
-    @mock.patch('sys.argv', ['feal', 'decrypt', '0x123456789ABCDEF0123456789ABCDEF', '0x9C9B54973DF685F8'])
+    @default_decrypt_args
     def test_integration_feal_decrypt(self):
         p = feal()
         self.assertEqual(int(p), 0x0)

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -99,3 +99,18 @@ class TestFeal(unittest.TestCase):
             self.assertEqual(p, '0x0')
 
         test_format_hex_with_decrypt()
+
+    def test_integration_feal_option_round_number(self):
+        @default_encrypt_args('-n', '16')
+        def test_round_number_with_encrypt():
+            c = feal()
+            self.assertEqual(int(c), 0x1A94383EB19BA07)
+
+        test_round_number_with_encrypt()
+
+        @default_decrypt_args('-n', '16', text='0x1A94383EB19BA07')
+        def test_round_number_with_decrypt():
+            p = feal()
+            self.assertEqual(int(p), 0x0)
+
+        test_round_number_with_decrypt()

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -6,32 +6,32 @@ import test.context
 from ciphers.feal import feal
 
 
-def mock_patch_wrapper(*args, **kwargs):
-    def wrapper(fn):
-        # wraps the test function
-        @mock.patch(*args, **kwargs)  # wraps the test function
-        def _wrapper(self):
-            # needed to pass the `self` argument from `unittest` to the test function
-            return fn(self)
+def mock_patch_wrapper(*default_args):
+    def additional_args_wrapper(*add_args):
+        def test_wrapper(fn):  # wraps the test function
+            @mock.patch('sys.argv', default_args + add_args)
+            def wrapper(self):  # needed to pass the `self` argument from `unittest` to the test function
+                return fn(self)
 
-        return _wrapper
+            return wrapper
 
-    return wrapper
+        return test_wrapper
+
+    return additional_args_wrapper
 
 
-default_encrypt_args = mock_patch_wrapper('sys.argv', ['feal', 'encrypt', '0x123456789ABCDEF0123456789ABCDEF', '0'])
+default_encrypt_args = mock_patch_wrapper('feal', 'encrypt', '0x123456789ABCDEF0123456789ABCDEF', '0')
 
-default_decrypt_args = mock_patch_wrapper(
-    'sys.argv', ['feal', 'decrypt', '0x123456789ABCDEF0123456789ABCDEF', '0x9C9B54973DF685F8'])
+default_decrypt_args = mock_patch_wrapper('feal', 'decrypt', '0x123456789ABCDEF0123456789ABCDEF', '0x9C9B54973DF685F8')
 
 
 class TestFeal(unittest.TestCase):
-    @default_encrypt_args
+    @default_encrypt_args()
     def test_integration_feal_encrypt(self):
         c = feal()
         self.assertEqual(int(c), 0x9C9B54973DF685F8)
 
-    @default_decrypt_args
+    @default_decrypt_args()
     def test_integration_feal_decrypt(self):
         p = feal()
         self.assertEqual(int(p), 0x0)

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -38,5 +38,5 @@ class TestFeal(unittest.TestCase):
 
     @default_decrypt_args('-o', 'bin')
     def test_integration_feal_output_format_bin(self):
-        c = feal()
-        self.assertEqual(c, bin(0x0))
+        p = feal()
+        self.assertEqual(p, bin(0x0))

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -36,7 +36,7 @@ class TestFeal(unittest.TestCase):
         p = feal()
         self.assertEqual(int(p), 0x0)
 
-    def test_integration_feal_output_format_bin(self):
+    def test_integration_feal_option_output_format_bin(self):
         @default_encrypt_args('-o', 'bin')
         def test_format_bin_with_encrypt():
             c = feal()
@@ -51,7 +51,7 @@ class TestFeal(unittest.TestCase):
 
         test_format_bin_with_decrypt()
 
-    def test_integration_feal_output_format_oct(self):
+    def test_integration_feal_option_output_format_oct(self):
         @default_encrypt_args('-o', 'oct')
         def test_format_oct_with_encrypt():
             c = feal()
@@ -66,7 +66,7 @@ class TestFeal(unittest.TestCase):
 
         test_format_oct_with_decrypt()
 
-    def test_integration_feal_output_format_dec(self):
+    def test_integration_feal_option_output_format_dec(self):
         @default_encrypt_args('-o', 'dec')
         def test_format_dec_with_encrypt():
             c = feal()
@@ -81,7 +81,7 @@ class TestFeal(unittest.TestCase):
 
         test_format_dec_with_decrypt()
 
-    def test_integration_feal_output_format_hex(self):
+    def test_integration_feal_option_output_format_hex(self):
         @default_encrypt_args('-o', 'hex')
         def test_format_hex_with_encrypt():
             c = feal()

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -6,12 +6,15 @@ import test.context
 from ciphers.feal import feal
 
 
-def patch_sysv_wrapper(*default_args):
-    def additional_args_wrapper(*add_args):
+def patch_sysv_wrapper(*default_args, **default_kwargs):
+    def additional_args_wrapper(*add_args, **add_kwargs):
+        kwargs = dict(default_kwargs, **add_kwargs)
+        args = list(default_args + add_args) + [kwargs['key'], kwargs['text']]
+
         def test_wrapper(fn):  # wraps the test function
-            @mock.patch('sys.argv', default_args + add_args)
-            def wrapper(*args):  # needed to pass the `self` argument from `unittest` to the test function
-                return fn(*args)
+            @mock.patch('sys.argv', args)
+            def wrapper(*_args):  # needed to pass the `self` argument from `unittest` to the test function
+                return fn(*_args)
 
             return wrapper
 
@@ -20,9 +23,10 @@ def patch_sysv_wrapper(*default_args):
     return additional_args_wrapper
 
 
-default_encrypt_args = patch_sysv_wrapper('feal', 'encrypt', '0x123456789ABCDEF0123456789ABCDEF', '0')
+default_encrypt_args = patch_sysv_wrapper('feal', 'encrypt', key='0x123456789ABCDEF0123456789ABCDEF', text='0')
 
-default_decrypt_args = patch_sysv_wrapper('feal', 'decrypt', '0x123456789ABCDEF0123456789ABCDEF', '0x9C9B54973DF685F8')
+default_decrypt_args = patch_sysv_wrapper('feal', 'decrypt', key='0x123456789ABCDEF0123456789ABCDEF',
+                                          text='0x9C9B54973DF685F8')
 
 
 class TestFeal(unittest.TestCase):

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -36,22 +36,62 @@ class TestFeal(unittest.TestCase):
         p = feal()
         self.assertEqual(int(p), 0x0)
 
-    @default_decrypt_args('-o', 'bin')
     def test_integration_feal_output_format_bin(self):
-        p = feal()
-        self.assertEqual(p, '0b0')
+        @default_encrypt_args('-o', 'bin')
+        def test_format_bin_with_encrypt():
+            c = feal()
+            self.assertEqual(c, '0b1001110010011011010101001001011100111101111101101000010111111000')
 
-    @default_decrypt_args('-o', 'oct')
+        test_format_bin_with_encrypt()
+
+        @default_decrypt_args('-o', 'bin')
+        def test_format_bin_with_decrypt():
+            p = feal()
+            self.assertEqual(p, '0b0')
+
+        test_format_bin_with_decrypt()
+
     def test_integration_feal_output_format_oct(self):
-        p = feal()
-        self.assertEqual(p, '0o0')
+        @default_encrypt_args('-o', 'oct')
+        def test_format_oct_with_encrypt():
+            c = feal()
+            self.assertEqual(c, '0o1162332511347575502770')
 
-    @default_decrypt_args('-o', 'dec')
+        test_format_oct_with_encrypt()
+
+        @default_decrypt_args('-o', 'oct')
+        def test_format_oct_with_decrypt():
+            p = feal()
+            self.assertEqual(p, '0o0')
+
+        test_format_oct_with_decrypt()
+
     def test_integration_feal_output_format_dec(self):
-        p = feal()
-        self.assertEqual(p, '0')
+        @default_encrypt_args('-o', 'dec')
+        def test_format_dec_with_encrypt():
+            c = feal()
+            self.assertEqual(c, '11284706299863270904')
 
-    @default_decrypt_args('-o', 'hex')
+        test_format_dec_with_encrypt()
+
+        @default_decrypt_args('-o', 'dec')
+        def test_format_dec_with_decrypt():
+            p = feal()
+            self.assertEqual(p, '0')
+
+        test_format_dec_with_decrypt()
+
     def test_integration_feal_output_format_hex(self):
-        p = feal()
-        self.assertEqual(p, '0x0')
+        @default_encrypt_args('-o', 'hex')
+        def test_format_hex_with_encrypt():
+            c = feal()
+            self.assertEqual(c, '0x9c9b54973df685f8')
+
+        test_format_hex_with_encrypt()
+
+        @default_decrypt_args('-o', 'hex')
+        def test_format_hex_with_decrypt():
+            p = feal()
+            self.assertEqual(p, '0x0')
+
+        test_format_hex_with_decrypt()

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -6,7 +6,7 @@ import test.context
 from ciphers.feal import feal
 
 
-def mock_patch_wrapper(*default_args):
+def patch_sysv_wrapper(*default_args):
     def additional_args_wrapper(*add_args):
         def test_wrapper(fn):  # wraps the test function
             @mock.patch('sys.argv', default_args + add_args)
@@ -20,9 +20,9 @@ def mock_patch_wrapper(*default_args):
     return additional_args_wrapper
 
 
-default_encrypt_args = mock_patch_wrapper('feal', 'encrypt', '0x123456789ABCDEF0123456789ABCDEF', '0')
+default_encrypt_args = patch_sysv_wrapper('feal', 'encrypt', '0x123456789ABCDEF0123456789ABCDEF', '0')
 
-default_decrypt_args = mock_patch_wrapper('feal', 'decrypt', '0x123456789ABCDEF0123456789ABCDEF', '0x9C9B54973DF685F8')
+default_decrypt_args = patch_sysv_wrapper('feal', 'decrypt', '0x123456789ABCDEF0123456789ABCDEF', '0x9C9B54973DF685F8')
 
 
 class TestFeal(unittest.TestCase):

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -39,4 +39,19 @@ class TestFeal(unittest.TestCase):
     @default_decrypt_args('-o', 'bin')
     def test_integration_feal_output_format_bin(self):
         p = feal()
-        self.assertEqual(p, bin(0x0))
+        self.assertEqual(p, '0b0')
+
+    @default_decrypt_args('-o', 'oct')
+    def test_integration_feal_output_format_oct(self):
+        p = feal()
+        self.assertEqual(p, '0o0')
+
+    @default_decrypt_args('-o', 'dec')
+    def test_integration_feal_output_format_dec(self):
+        p = feal()
+        self.assertEqual(p, '0')
+
+    @default_decrypt_args('-o', 'hex')
+    def test_integration_feal_output_format_hex(self):
+        p = feal()
+        self.assertEqual(p, '0x0')

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -1,0 +1,13 @@
+import unittest
+from unittest import mock
+
+# noinspection PyUnresolvedReferences
+import test.context
+from ciphers.feal import feal
+
+
+class TestFeal(unittest.TestCase):
+    @mock.patch('sys.argv', ['feal', 'encrypt', '0x123456789ABCDEF0123456789ABCDEF', '0'])
+    def test_feal_encrypt_from_cmdline(self):
+        c = feal()
+        self.assertEqual(int(c), 0x9C9B54973DF685F8)

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -8,6 +8,6 @@ from ciphers.feal import feal
 
 class TestFeal(unittest.TestCase):
     @mock.patch('sys.argv', ['feal', 'encrypt', '0x123456789ABCDEF0123456789ABCDEF', '0'])
-    def test_feal_encrypt_from_cmdline(self):
+    def test_integration_feal_encrypt(self):
         c = feal()
         self.assertEqual(int(c), 0x9C9B54973DF685F8)

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -23,7 +23,7 @@ def patch_sysv_wrapper(*default_args, **default_kwargs):
     return additional_args_wrapper
 
 
-default_encrypt_args = patch_sysv_wrapper('feal', 'encrypt', key='0x123456789ABCDEF0123456789ABCDEF', text='0')
+default_encrypt_args = patch_sysv_wrapper('feal', 'encrypt', key='0x123456789ABCDEF0123456789ABCDEF', text='0x0')
 
 default_decrypt_args = patch_sysv_wrapper('feal', 'decrypt', key='0x123456789ABCDEF0123456789ABCDEF',
                                           text='0x9C9B54973DF685F8')

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -13,8 +13,8 @@ def patch_sysv_wrapper(*default_args, **default_kwargs):
 
         def test_wrapper(fn):  # wraps the test function
             @mock.patch('sys.argv', args)
-            def wrapper(*_args):  # needed to pass the `self` argument from `unittest` to the test function
-                return fn(*_args)
+            def wrapper(*unittest_args):  # needed to pass the `self` argument from `unittest` to the test function
+                return fn(*unittest_args)
 
             return wrapper
 

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -11,3 +11,8 @@ class TestFeal(unittest.TestCase):
     def test_integration_feal_encrypt(self):
         c = feal()
         self.assertEqual(int(c), 0x9C9B54973DF685F8)
+
+    @mock.patch('sys.argv', ['feal', 'decrypt', '0x123456789ABCDEF0123456789ABCDEF', '0x9C9B54973DF685F8'])
+    def test_integration_feal_decrypt(self):
+        p = feal()
+        self.assertEqual(int(p), 0x0)

--- a/test/ciphers/feal/test_feal.py
+++ b/test/ciphers/feal/test_feal.py
@@ -10,8 +10,8 @@ def patch_sysv_wrapper(*default_args):
     def additional_args_wrapper(*add_args):
         def test_wrapper(fn):  # wraps the test function
             @mock.patch('sys.argv', default_args + add_args)
-            def wrapper(self):  # needed to pass the `self` argument from `unittest` to the test function
-                return fn(self)
+            def wrapper(*args):  # needed to pass the `self` argument from `unittest` to the test function
+                return fn(*args)
 
             return wrapper
 

--- a/test/ciphers/feal/test_feal_decrypt.py
+++ b/test/ciphers/feal/test_feal_decrypt.py
@@ -9,17 +9,17 @@ class TestFEALCipherDecrypt(unittest.TestCase):
 
     def test_decrypt_raises_value_error_if_text_larger_than_64_bit(self):
         with self.assertRaises(ValueError):
-            decrypt(2 ** 64, 0x0)
+            decrypt(0x0, 2 ** 64)
         try:
-            decrypt(2 ** 64 - 1, 0x0)
+            decrypt(0x0, 2 ** 64 - 1)
         except ValueError:
             self.fail("decrypt raised unexpected ValueError")
 
     def test_decrypt_raises_value_error_if_key_larger_than_128_bit(self):
         with self.assertRaises(ValueError):
-            decrypt(0x0, 2 ** 128)
+            decrypt(2 ** 128, 0x0)
         try:
-            decrypt(0x0, 2 ** 128 - 1)
+            decrypt(2 ** 128 - 1, 0x0)
         except ValueError:
             self.fail("decrypt raised unexpected ValueError")
 
@@ -31,7 +31,7 @@ class TestFEALCipherDecrypt(unittest.TestCase):
         #   and expect the input of encrypt as output of decrypt.
         c = 0x9C9B54973DF685F8
         k = 0x123456789ABCDEF0123456789ABCDEF
-        p = decrypt(c, k)
+        p = decrypt(k, c)
         self.assertEqual(p, 0x0)
 
     def test_decrypt_preprocessing_matches_specification_in_paper(self):
@@ -40,7 +40,7 @@ class TestFEALCipherDecrypt(unittest.TestCase):
         #   during encryption should be returned when using the output of said encryption as input.
         k34, k35, k36, k37 = 0x9F72, 0x6643, 0xAD32, 0x683A
         c = 0x9C9B54973DF685F8
-        out = decrypt_preprocessing(c, [k34, k35, k36, k37])
+        out = decrypt_preprocessing([k34, k35, k36, k37], c)
         self.assertEqual(out, 0x03E932D4932DDF16)
 
     def test_decrypt_iterative_calculation_matches_specification_in_paper(self):

--- a/test/ciphers/feal/test_feal_encrypt.py
+++ b/test/ciphers/feal/test_feal_encrypt.py
@@ -9,17 +9,17 @@ class TestFEALCipherEncrypt(unittest.TestCase):
 
     def test_encrypt_raises_value_error_if_text_larger_than_64_bit(self):
         with self.assertRaises(ValueError):
-            encrypt(2 ** 64, 0x0)
+            encrypt(0x0, 2 ** 64)
         try:
-            encrypt(2 ** 64 - 1, 0x0)
+            encrypt(0x0, 2 ** 64 - 1)
         except ValueError:
             self.fail("encrypt raised unexpected ValueError")
 
     def test_encrypt_raises_value_error_if_key_larger_than_128_bit(self):
         with self.assertRaises(ValueError):
-            encrypt(0, 2 ** 128)
+            encrypt(2 ** 128, 0)
         try:
-            encrypt(0, 2 ** 128 - 1)
+            encrypt(2 ** 128 - 1, 0)
         except ValueError:
             self.fail("encrypt raised unexpected ValueError")
 
@@ -29,7 +29,7 @@ class TestFEALCipherEncrypt(unittest.TestCase):
         #   https://info.isl.ntt.co.jp/crypt/archive/dl/feal/call-3e.pdf
         k = 0x123456789ABCDEF0123456789ABCDEF
         p = 0x0
-        c = encrypt(p, k)
+        c = encrypt(k, p)
         self.assertEqual(c, 0x9C9B54973DF685F8)
 
     def test_encrypt_preprocessing_matches_specification_in_paper(self):
@@ -37,7 +37,7 @@ class TestFEALCipherEncrypt(unittest.TestCase):
         #   https://info.isl.ntt.co.jp/crypt/archive/dl/feal/call-3e.pdf
         k32, k33, k34, k35 = 0x196A, 0x9AB1, 0xE015, 0x8190
         p = 0x0
-        out = encrypt_preprocessing(p, [k32, k33, k34, k35])
+        out = encrypt_preprocessing([k32, k33, k34, k35], p)
         self.assertEqual(out, 0x196A9AB1F97F1B21)
 
     def test_encrypt_iterative_calculation_matches_specification_in_paper(self):


### PR DESCRIPTION
Created integration tests in test.ciphers.feal.test_feal thus this closes #4 

They work by mocking `sys.argv`.

For example: 
```python
from ciphers.feal import feal

@mock.patch('sys.argv', ['feal', 'encrypt', '0x123456789ABCDEF0123456789ABCDEF', '0x0')
def test_integration_feal_encrypt(self):
    c = feal()
    self.assertEqual(int(c), 0x9C9B54973DF685F8)
```

Also [changed signature of cipher functions](https://github.com/ekzyis/cryptanalysis/commit/1c2c2080937b76a5281a6672c0d038698f6fe8b2) to match the usage pattern
```
feal encrypt [options] KEY PLAINTEXT
feal decrypt [options] KEY CIPHERTEXT
```
where first comes the key and then the input text.

This inconsistent pattern in usage and function signature was already confusing for me so I changed it asap to not run into more confusing problems later on.

Furthermore, I created for easier testing a wrapper for mocking `sys.argv`:

```python
def patch_sysv_wrapper(*default_args, **default_kwargs):
    def additional_args_wrapper(*add_args, **add_kwargs):
        kwargs = dict(default_kwargs, **add_kwargs)
        args = list(default_args + add_args) + [kwargs['key'], kwargs['text']]

        def test_wrapper(fn):  # wraps the test function
            @mock.patch('sys.argv', args)
            def wrapper(*_args):  # needed to pass the `self` argument from `unittest` to the test function
                return fn(*_args)

            return wrapper

        return test_wrapper

    return additional_args_wrapper


default_encrypt_args = patch_sysv_wrapper('feal', 'encrypt', key='0x123456789ABCDEF0123456789ABCDEF', text='0x0')

default_decrypt_args = patch_sysv_wrapper('feal', 'decrypt', key='0x123456789ABCDEF0123456789ABCDEF',
                                          text='0x9C9B54973DF685F8')
```

With it, I can reuse the default arguments without having to specify them over and over again and also replace the key and/or text with other values where needed:

```python
@default_encrypt_args()
def test_integration_feal_encrypt(self):
    c = feal()
    self.assertEqual(int(c), 0x9C9B54973DF685F8)
```

```python
@default_decrypt_args('-n', '16', text='0x1A94383EB19BA07')
def test_round_number_with_decrypt():
    p = feal()
    self.assertEqual(int(p), 0x0)
```