### PR TITLE
Installed python module pycodestyle

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 bitarray==1.2.1
 coverage==5.1
 docopt==0.6.2
+pycodestyle==2.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 120


### PR DESCRIPTION
Installed python module `pycodestyle` (formerly known as `pep8`)

Added setup.cfg to set maximal line length to 120.

close #10